### PR TITLE
Make file and dir server more efficient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build/
 /_corral/
 /_repos/
+/lock.json

--- a/jennet/jennet.pony
+++ b/jennet/jennet.pony
@@ -97,7 +97,7 @@ class iso Jennet
     Serve static file located at the relative filepath when GET requests are
     received for the given path.
     """
-    let caps = recover val FileCaps + FileRead + FileStat end
+    let caps = recover val FileCaps + FileRead + FileStat + FileSeek end
     _add_route("GET", path, _FileServer(FilePath(auth, filepath, caps)), [])
 
   fun ref serve_dir(auth: FileAuth, path: String, dir: String) =>
@@ -105,7 +105,7 @@ class iso Jennet
     Serve all files in dir using the incomming url path suffix denoted by
     `*filepath` in the given path.
     """
-    let caps = recover val FileCaps + FileRead + FileStat + FileLookup end
+    let caps = recover val FileCaps + FileRead + FileStat + FileLookup + FileSeek end
     _add_route("GET", path, _DirServer(FilePath(auth, dir, caps)), [])
 
   fun ref not_found(handler: RequestHandler) =>


### PR DESCRIPTION
by stating the file first and then try to read the whole file in as few read calls as possible.

This does not solve the problem of having to allocate space for the whole file in memory.

This addresses some of the issues in #28 